### PR TITLE
Feat: 모임 가입 요청 수락 & 거절 api 연동

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,6 @@ export default function RootLayout({
   const historyHeaderList = ["/user/onboarding", "/user/club"];
 
   const clubHeaderList = [
-    "/info",
     "/member/attendance",
   ];
 

--- a/src/components/molecules/headerInfo/HeaderInfo.tsx
+++ b/src/components/molecules/headerInfo/HeaderInfo.tsx
@@ -45,7 +45,11 @@ export function HeaderInfo({
 }: isHeaderInfo) {
   const router = useRouter();
   const saveData = useSelector((state: RootState) => state.club.children);
-  const { data: loadData } = useMemberAuthQuery();
+  const { data: loadData, isError, error } = useMemberAuthQuery();
+  if (isError) {
+    console.log(error.response?.status);
+    if (error.response?.status) router.push('/user/onboarding');
+  }
   if (loadData === undefined) return;
   const clubInfo = saveData.memberId === -1 ? loadData.data : saveData;
   return (

--- a/src/features/home/SetHome.tsx
+++ b/src/features/home/SetHome.tsx
@@ -38,7 +38,7 @@ const SetHome = () => {
   return (
     <ScheduleContext.Provider value={{ value, onChange: setValue }}>
       <HeaderInfo isClubInfo={true} isMyInfo={true} />
-      <div style={{ height: "100%", paddingBottom: "4.25rem", paddingTop: "4.25rem" }}>
+      <div style={{ height: "100%", paddingBottom: "4.25rem", paddingTop: "4.25rem", backgroundColor: "#2B2B2B" }}>
         <HomeHeader mark={mark} />
         <HomeDateWrapper dateList={filteredData} isLoading={isLoading} />
       </div>

--- a/src/features/info/ManagerInfo.tsx
+++ b/src/features/info/ManagerInfo.tsx
@@ -7,7 +7,9 @@ export default function ManagerInfo () {
     return(
         <>
             <Wrapper isHeader={true}>
-                <MemberContent />
+                <div style={{ paddingTop: '4.25rem' }}>   
+                    <MemberContent />
+                </div>
                 <div className="memberInfo">
                     <MemberBtn />
                     <Nav />

--- a/src/features/info/manage/join/ManageJoin.tsx
+++ b/src/features/info/manage/join/ManageJoin.tsx
@@ -6,37 +6,45 @@ import ManageJoinHeader from "./components/ManageJoinHeader";
 import ManageJoinList from "./components/ManageJoinList";
 import ManageJoinWrapper from "./components/ManageJoinWrapper";
 
+import { ClubJoin } from "@/types/info";
 import { useState } from "react";
 import "./components/ManageJoin.css";
+
+const ManageJoinContent = ({ 
+    joinList
+}: {
+    joinList: ClubJoin[]
+}) => {
+  const [selectJoins, setSelectJoins] = useState<number[]>([]);
+
+  return (
+    <>
+      <ManageJoinHeader 
+        memberCnt={joinList.length}
+        selectJoins={selectJoins}
+      />
+      <ManageJoinList 
+        joinList={joinList}
+        selectJoins={selectJoins}
+        setSelectJoins={setSelectJoins}
+      />
+    </>
+  );
+};
+
 export const ManageJoin = () => {
-    const { data: joinList } = useClubJoinQuery();
-    console.log(joinList);
+  const { data: joinList } = useClubJoinQuery();
+  console.log(joinList);
 
-    const [selectJoins, setSelectJoins] = useState<number[]>([]);
-
-    return(
-        <>
-            <HistoryHeader 
-                title="모임 가입 신청 관리"
-            />
-            <ManageJoinWrapper>
-                {
-                    joinList &&
-                    joinList.data &&
-                    <>
-                        <ManageJoinHeader 
-                            memberCnt={joinList.data.length}
-                            selectJoins={selectJoins}
-                        />
-                        <ManageJoinList 
-                            joinList={joinList.data}
-                            selectJoins={selectJoins}
-                            setSelectJoins={setSelectJoins}
-                        />
-                    </>
-                }
-            </ManageJoinWrapper>
-            <Nav />
-        </>
-    )
+  return (
+    <>
+      <HistoryHeader title="모임 가입 신청 관리" />
+      <ManageJoinWrapper>
+        {joinList && joinList.data && (
+          <ManageJoinContent joinList={joinList.data} />
+        )}
+      </ManageJoinWrapper>
+      <Nav />
+    </>
+  );
 };

--- a/src/features/info/manage/join/components/ManageJoinBox.tsx
+++ b/src/features/info/manage/join/components/ManageJoinBox.tsx
@@ -1,6 +1,7 @@
 import { Checkbox } from "@/components/atoms/checkbox/Checkbox";
 import { Text } from "@/components/atoms/text";
 import { COLORS } from "@/styles";
+import moment from "moment";
 
 interface manageJoinBoxProps {
   idx: number;
@@ -45,7 +46,7 @@ export default function ManageJoinBox({
             color={COLORS.white}
             fontSize="0.75rem"
             fontWeight="500"
-          >{date}</Text>
+          >{moment(date).format("YYYY년 MM월 DD일")}</Text>
         </p>
       </div>
       <Checkbox

--- a/src/features/info/manage/join/components/ManageJoinHeader.tsx
+++ b/src/features/info/manage/join/components/ManageJoinHeader.tsx
@@ -3,6 +3,8 @@ import { COLORS } from "@/styles";
 import { BTN, NUMBER, TOTAL } from "../constants";
 
 import { Text } from "@/components/atoms/text";
+import { useClubJoinAcceptMutation } from "@/hook/info/useClubJoinAcceptMutation";
+import { useClubJoinDenyMutation } from "@/hook/info/useClubJoinDenyMutation";
 import "./ManageJoin.css";
 
 export default function ManageJoinHeader({
@@ -12,8 +14,18 @@ export default function ManageJoinHeader({
   memberCnt: number;
   selectJoins: number[];
 }) {
+  const { mutate: acceptMutate } = useClubJoinAcceptMutation();
+  const { mutate: denyMutate } = useClubJoinDenyMutation();
+  
   const mutationJoin = (type: boolean) => {
-
+    console.log(type, selectJoins);
+    if (type) {
+      console.log("Calling acceptMutate");
+      acceptMutate(selectJoins);
+    } else {
+      console.log("Calling denyMutate");
+      denyMutate(selectJoins);
+    }
   }
   return (
     <div className="manageJoinHeader">

--- a/src/features/info/manage/join/components/ManageJoinHeader.tsx
+++ b/src/features/info/manage/join/components/ManageJoinHeader.tsx
@@ -20,10 +20,8 @@ export default function ManageJoinHeader({
   const mutationJoin = (type: boolean) => {
     console.log(type, selectJoins);
     if (type) {
-      console.log("Calling acceptMutate");
       acceptMutate(selectJoins);
     } else {
-      console.log("Calling denyMutate");
       denyMutate(selectJoins);
     }
   }

--- a/src/features/info/manage/join/components/ManageJoinList.tsx
+++ b/src/features/info/manage/join/components/ManageJoinList.tsx
@@ -48,10 +48,10 @@ export default function ManageJoinList({
       <div className="manageJoinList__content">
         {
           joinList
-            ?.map((item) => 
+            ?.map((item, idx) => 
               <ManageJoinBox
-                key={item.id}
-                idx={item.id}
+                key={idx}
+                idx={idx}
                 joinId={item.id}
                 name={item.userName}
                 date={item.createdAt}

--- a/src/hook/info/useClubJoinAcceptMutation.ts
+++ b/src/hook/info/useClubJoinAcceptMutation.ts
@@ -1,19 +1,19 @@
 import { http } from "@/apis/http"
-import { JoinRequestParam } from "@/types/info"
+import { FormatClubId } from "@/utils/extractPathElements"
 import useToast from "@/utils/useToast"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { AxiosError, AxiosResponse } from "axios"
 
 // 멤버 가입요청 수락 (/clubs/{clubId}/join/{clubJoinRequestId}/accept)
-export const useClubJoinAcceptMutation = ({
-  clubId,
-  clubJoinRequestId
-}: JoinRequestParam) => {
+export const useClubJoinAcceptMutation = () => {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
+  const clubId = FormatClubId();
 
-  return useMutation<AxiosResponse<string>, Error>({
-    mutationFn: () => http.post(`/${clubId}/join/${clubJoinRequestId}/accept`),
+  return useMutation<AxiosResponse<string>, Error, number[]>({
+    mutationFn: async (selectJoins: number[]) => {
+      return await http.post(`/clubs/${clubId}/join/accept`, selectJoins)
+    },
     onSuccess: (data) => {
       console.log(data);
       if (data.status === 200) {

--- a/src/hook/info/useClubJoinDenyMutation.ts
+++ b/src/hook/info/useClubJoinDenyMutation.ts
@@ -1,5 +1,5 @@
 import { http } from "@/apis/http"
-import { JoinRequestParam } from "@/types/info"
+import { FormatClubId } from "@/utils/extractPathElements"
 import useToast from "@/utils/useToast"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { AxiosError, AxiosResponse } from "axios"
@@ -11,15 +11,15 @@ interface ErrorData {
 }
 
 // 멤버 가입요청 거절 (/clubs/{clubId}/join/{clubJoinRequestId}/deny)
-export const useClubJoinDenyMutation = ({
-  clubId,
-  clubJoinRequestId
-}: JoinRequestParam) => {
+export const useClubJoinDenyMutation = () => {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
+  const clubId = FormatClubId();
 
-  return useMutation<AxiosResponse<string>, Error>({
-    mutationFn: () => http.post(`/${clubId}/join/${clubJoinRequestId}/deny`),
+  return useMutation<AxiosResponse<string>, Error, number[]>({
+    mutationFn: async (selectJoins: number[]) => {
+      return await http.post(`/clubs/${clubId}/join/deny`, selectJoins)
+    },
     onSuccess: (data) => {
       console.log(data);
       if (data.status === 200) {

--- a/src/hook/info/useMyCommentQuery.ts
+++ b/src/hook/info/useMyCommentQuery.ts
@@ -12,7 +12,7 @@ export const useMyCommentQuery = ({
   sort="",
 }: MyPostProps) => {
   const clubId = FormatClubId();
-  const myPostUrl = `/clubs/${clubId}/comment/my?page=${page}&size=${size}`;
+  const myPostUrl = `/clubs/${clubId}/posts/my-comment-list?page=${page}&size=${size}`;
   return useQuery<CommonRes<PostList>>({
     queryKey: ["postMyComment", { clubId, size, page, sort }],
     queryFn: async () => 

--- a/src/hook/member/useMemberAuthQuery.ts
+++ b/src/hook/member/useMemberAuthQuery.ts
@@ -1,15 +1,15 @@
 import { http } from "@/apis/http";
-import { CommonNoPageRes } from "@/types";
 import { MemberAuthInfo } from "@/types/member";
 import { FormatClubId } from "@/utils/extractPathElements";
 import { useQuery } from "@tanstack/react-query";
+import { AxiosError, AxiosResponse } from "axios";
 // 클럽 auth 조회
 export const useMemberAuthQuery = () => {
   const clubId = FormatClubId();
-  return useQuery<CommonNoPageRes<MemberAuthInfo>>({
+  return useQuery<AxiosResponse<MemberAuthInfo>, AxiosError>({
     queryKey: ["myClubAuth", [clubId]],
     queryFn: async () => {
-      const response = await http.get<CommonNoPageRes<MemberAuthInfo>>(
+      const response = await http.get<AxiosResponse<MemberAuthInfo>>(
         `/clubs/${clubId}/member/my/auth`
       );
       return response;

--- a/src/types/info/types.ts
+++ b/src/types/info/types.ts
@@ -40,5 +40,5 @@ export interface ClubJoin {
 
 export interface JoinRequestParam {
   clubId: number;
-  clubJoinRequestId: number;
+  clubJoinRequestId?: number;
 }


### PR DESCRIPTION
Feat: 모임 가입 요청 수락 & 거절 api 연동

## 🔘Part

-  더보기 - 모임 가입 요청

  <br/>

## 🔎 작업 내용

- 모임 가입 요청 수락 & 거절 api 를 연동했습니다.
- 멤버 초기 프로필 설정이 되지 않았을 경우 온보딩 화면으로 이동하도록 하였습니다.

  <br/>


## 🔧 앞으로의 과제

- 초기 프로필 설정 api 연동
- 닉네임제 | 실명제 조회 후 페이지 이동

  <br/>
